### PR TITLE
fix: do not automatically set EV station filters in query variables

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -17,9 +17,6 @@ from .cache import GasBuddyCache
 from .consts import (
     BASE_URL,
     DEFAULT_HEADERS,
-    EV_ALL_NETWORKS,
-    EV_CHARGING_LEVELS,
-    EV_CONNECTOR_TYPES,
     EV_STATIONS_BOUNDS_QUERY,
     EV_STATIONS_NEARBY_QUERY,
     GAS_PRICE_QUERY,
@@ -421,19 +418,24 @@ class GasBuddy:
             limit: Maximum stations to return (default 50).
         """
         self._validate_coordinates(lat, lon)
+        variables: dict[str, Any] = {
+            "latitude": lat,
+            "longitude": lon,
+            "radius": radius,
+            "accessCode": access_code,
+            "limit": limit,
+        }
+        if networks is not None:
+            variables["networks"] = networks
+        if connector_types is not None:
+            variables["connectorTypes"] = connector_types
+        if charging_levels is not None:
+            variables["chargingLevels"] = charging_levels
+
         query: GraphQLQuery = {
             "operationName": "EvStationsSearch",
             "query": EV_STATIONS_NEARBY_QUERY,
-            "variables": {
-                "latitude": lat,
-                "longitude": lon,
-                "radius": radius,
-                "networks": networks or EV_ALL_NETWORKS,
-                "connectorTypes": connector_types or EV_CONNECTOR_TYPES,
-                "chargingLevels": charging_levels or EV_CHARGING_LEVELS,
-                "accessCode": access_code,
-                "limit": limit,
-            },
+            "variables": variables,
         }
         response = await self.process_request(query)
         _LOGGER.debug("ev_stations_nearby response: %s", response)
@@ -486,20 +488,25 @@ class GasBuddy:
         """
         self._validate_coordinates(ne_lat, ne_lng)
         self._validate_coordinates(sw_lat, sw_lng)
+        variables: dict[str, Any] = {
+            "northEastLat": ne_lat,
+            "northEastLng": ne_lng,
+            "southWestLat": sw_lat,
+            "southWestLng": sw_lng,
+            "accessCode": access_code,
+            "limit": limit,
+        }
+        if networks is not None:
+            variables["networks"] = networks
+        if connector_types is not None:
+            variables["connectorTypes"] = connector_types
+        if charging_levels is not None:
+            variables["chargingLevels"] = charging_levels
+
         query: GraphQLQuery = {
             "operationName": "EvStationsByBounds",
             "query": EV_STATIONS_BOUNDS_QUERY,
-            "variables": {
-                "northEastLat": ne_lat,
-                "northEastLng": ne_lng,
-                "southWestLat": sw_lat,
-                "southWestLng": sw_lng,
-                "networks": networks or EV_ALL_NETWORKS,
-                "connectorTypes": connector_types or EV_CONNECTOR_TYPES,
-                "chargingLevels": charging_levels or EV_CHARGING_LEVELS,
-                "accessCode": access_code,
-                "limit": limit,
-            },
+            "variables": variables,
         }
         response = await self.process_request(query)
         _LOGGER.debug("ev_stations_by_bounds response: %s", response)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -864,6 +864,53 @@ async def test_ev_stations_nearby(mock_aioclient):
     assert s["nacs_count"] == 0
     assert s["phone"] == "1-833-632-2778"
     assert s["access_hours"] == "24 hours daily"
+
+    post_req = None
+    for key, reqs in mock_aioclient.requests.items():
+        if key[0] == "POST" and str(key[1]) == TEST_URL:
+            post_req = reqs[0]
+            break
+    assert post_req is not None
+    req_body = json.loads(post_req.kwargs["data"])
+    variables = req_body["variables"]
+    assert variables["latitude"] == 43.045
+    assert variables["longitude"] == -76.308
+    assert "networks" not in variables
+    assert "connectorTypes" not in variables
+    assert "chargingLevels" not in variables
+
+    await manager.clear_cache()
+
+
+async def test_ev_stations_nearby_with_filters(mock_aioclient):
+    """Test ev_stations_nearby with explicit networks, connector types, and charging levels."""
+    mock_aioclient.get(GB_URL, status=200, body=load_fixture("index.html"), repeat=True)
+    mock_aioclient.post(TEST_URL, status=200, body=load_fixture("ev_nearby.json"))
+    manager = py_gasbuddy.GasBuddy()
+    result = await manager.ev_stations_nearby(
+        lat=43.045,
+        lon=-76.308,
+        networks="Tesla,ChargePoint",
+        connector_types="CHADEMO,TESLA",
+        charging_levels="DCFast,Level2",
+    )
+
+    assert result["total"] == 2
+
+    post_req = None
+    for key, reqs in mock_aioclient.requests.items():
+        if key[0] == "POST" and str(key[1]) == TEST_URL:
+            post_req = reqs[0]
+            break
+    assert post_req is not None
+    req_body = json.loads(post_req.kwargs["data"])
+    variables = req_body["variables"]
+    assert variables["latitude"] == 43.045
+    assert variables["longitude"] == -76.308
+    assert variables["networks"] == "Tesla,ChargePoint"
+    assert variables["connectorTypes"] == "CHADEMO,TESLA"
+    assert variables["chargingLevels"] == "DCFast,Level2"
+
     await manager.clear_cache()
 
 
@@ -908,6 +955,59 @@ async def test_ev_stations_by_bounds(mock_aioclient):
     assert s["dc_fast_count"] == 8
     assert s["ccs_count"] == 0
     assert s["pricing"] == "$0.37/kWh"
+
+    post_req = None
+    for key, reqs in mock_aioclient.requests.items():
+        if key[0] == "POST" and str(key[1]) == TEST_URL:
+            post_req = reqs[0]
+            break
+    assert post_req is not None
+    req_body = json.loads(post_req.kwargs["data"])
+    variables = req_body["variables"]
+    assert variables["northEastLat"] == 43.85
+    assert variables["northEastLng"] == -81.68
+    assert variables["southWestLat"] == 35.55
+    assert variables["southWestLng"] == -115.48
+    assert "networks" not in variables
+    assert "connectorTypes" not in variables
+    assert "chargingLevels" not in variables
+
+    await manager.clear_cache()
+
+
+async def test_ev_stations_by_bounds_with_filters(mock_aioclient):
+    """Test ev_stations_by_bounds with explicit networks, connector types, and charging levels."""
+    mock_aioclient.get(GB_URL, status=200, body=load_fixture("index.html"), repeat=True)
+    mock_aioclient.post(TEST_URL, status=200, body=load_fixture("ev_bounds.json"))
+    manager = py_gasbuddy.GasBuddy()
+    result = await manager.ev_stations_by_bounds(
+        ne_lat=43.85,
+        ne_lng=-81.68,
+        sw_lat=35.55,
+        sw_lng=-115.48,
+        networks="Tesla,ChargePoint",
+        connector_types="CHADEMO,TESLA",
+        charging_levels="DCFast,Level2",
+    )
+
+    assert result["total"] == 1
+
+    post_req = None
+    for key, reqs in mock_aioclient.requests.items():
+        if key[0] == "POST" and str(key[1]) == TEST_URL:
+            post_req = reqs[0]
+            break
+    assert post_req is not None
+    req_body = json.loads(post_req.kwargs["data"])
+    variables = req_body["variables"]
+    assert variables["northEastLat"] == 43.85
+    assert variables["northEastLng"] == -81.68
+    assert variables["southWestLat"] == 35.55
+    assert variables["southWestLng"] == -115.48
+    assert variables["networks"] == "Tesla,ChargePoint"
+    assert variables["connectorTypes"] == "CHADEMO,TESLA"
+    assert variables["chargingLevels"] == "DCFast,Level2"
+
     await manager.clear_cache()
 
 


### PR DESCRIPTION
This PR changes `ev_stations_nearby` and `ev_stations_by_bounds` so that `networks`, `connector_types`, and `charging_levels` are omitted from the GraphQL variables when they are not explicitly specified (i.e. they are `None`). This prevents automatically setting them to default constants in every query, allowing the backend server defaults/fallback behavior to work as expected.

All modified lines are fully covered by unit tests (confirmed by 100% test coverage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EV station query efficiency by omitting unused filter parameters when not specified, reducing unnecessary request payload.

* **Tests**
  * Extended test coverage for EV station queries to verify correct behavior with and without filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/py-gasbuddy/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->