### PR TITLE
fix: treat null payStatus as deal-eligible (Flash Deal stations)

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -295,10 +295,12 @@ class GasBuddy:
             "enterprise": bool(station.get("enterprise", False)),
             "emergency_status": station.get("emergencyStatus"),
             "offers": station.get("offers") or [],
-            "pay_status": bool(
-                (station.get("payStatus") or {}).get("isPayAvailable", False)
-            ),
         }
+
+        pay_status_obj = station.get("payStatus")
+        raw["pay_status"] = (pay_status_obj is None) or bool(
+            (pay_status_obj or {}).get("isPayAvailable", False)
+        )
 
         _LOGGER.debug("pre-price data: %s", raw)
 

--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -302,7 +302,9 @@ class GasBuddy:
 
         _LOGGER.debug("pre-price data: %s", raw)
 
-        discount_map = build_discount_map(station.get("offers") or [])
+        discount_map = (
+            build_discount_map(station.get("offers") or []) if raw["pay_status"] else {}
+        )
         for price in station.get("prices") or []:
             fuel_key = price["fuelProduct"]
             raw[fuel_key] = format_price_node(price, discount_map.get(fuel_key))

--- a/py_gasbuddy/consts.py
+++ b/py_gasbuddy/consts.py
@@ -429,6 +429,9 @@ query LocationBySearchTerm(
           types
           use
         }
+        payStatus {
+          isPayAvailable
+        }
       }
     }
     trends {

--- a/py_gasbuddy/consts.py
+++ b/py_gasbuddy/consts.py
@@ -274,6 +274,7 @@ query GetStation($id: ID!) {
         pwgbDiscount
         receiptDiscount
       }
+      duration
       highlight
       id
       types
@@ -424,6 +425,7 @@ query LocationBySearchTerm(
             pwgbDiscount
             receiptDiscount
           }
+          duration
           highlight
           id
           types

--- a/py_gasbuddy/parsers.py
+++ b/py_gasbuddy/parsers.py
@@ -122,7 +122,9 @@ def parse_results(response: dict[str, Any], limit: int) -> list[StationPrice]:
             "ratings_count": result.get("ratingsCount"),
             "fuels": result.get("fuels") or [],
         }
-        discount_map = build_discount_map(result.get("offers") or [])
+        is_pay_available = bool((result.get("payStatus") or {}).get("isPayAvailable", False))
+        raw["pay_status"] = is_pay_available
+        discount_map = build_discount_map(result.get("offers") or []) if is_pay_available else {}
         for price in result.get("prices") or []:
             fuel_key = price["fuelProduct"]
             raw[fuel_key] = format_price_node(price, discount_map.get(fuel_key))

--- a/py_gasbuddy/parsers.py
+++ b/py_gasbuddy/parsers.py
@@ -122,9 +122,13 @@ def parse_results(response: dict[str, Any], limit: int) -> list[StationPrice]:
             "ratings_count": result.get("ratingsCount"),
             "fuels": result.get("fuels") or [],
         }
-        is_pay_available = bool((result.get("payStatus") or {}).get("isPayAvailable", False))
+        pay_status_obj = result.get("payStatus")
+        is_pay_available = (pay_status_obj is None) or bool(
+            (pay_status_obj or {}).get("isPayAvailable", False)
+        )
         raw["pay_status"] = is_pay_available
-        discount_map = build_discount_map(result.get("offers") or []) if is_pay_available else {}
+        offers = result.get("offers") or []
+        discount_map = build_discount_map(offers) if is_pay_available else {}
         for price in result.get("prices") or []:
             fuel_key = price["fuelProduct"]
             raw[fuel_key] = format_price_node(price, discount_map.get(fuel_key))

--- a/tests/fixtures/prices_gps.json
+++ b/tests/fixtures/prices_gps.json
@@ -121,6 +121,41 @@
                         "payStatus": {"isPayAvailable": false}
                     },
                     {
+                        "address": {"country": "US", "line1": "100 Test Blvd", "line2": null, "locality": "Springfield", "postalCode": "62701", "region": "IL"},
+                        "brands": [{"brandId": 77, "brandingType": "branded", "imageUrl": "https://images.gasbuddy.io/b/77.png", "name": "TestMart"}],
+                        "distance": 0.9,
+                        "fuels": ["regular_gas", "midgrade_gas", "premium_gas"],
+                        "id": "999001",
+                        "latitude": 39.781721,
+                        "longitude": -89.650148,
+                        "name": "TestMart",
+                        "priceUnit": "dollars_per_gallon",
+                        "currency": "USD",
+                        "ratingsCount": 10,
+                        "starRating": 4.0,
+                        "prices": [
+                            {
+                                "cash": null,
+                                "credit": {"nickname": "user123", "postedTime": "2024-11-18T21:58:38.859Z", "price": 3.20, "formattedPrice": "$3.20"},
+                                "fuelProduct": "regular_gas",
+                                "longName": "Regular"
+                            }
+                        ],
+                        "offers": [
+                            {
+                                "discounts": [
+                                    {"grades": ["regular_gas", "midgrade_gas", "premium_gas"], "highlight": "Flash Deal: Save 10¢ per gallon", "pwgbDiscount": "0.10", "receiptDiscount": null}
+                                ],
+                                "duration": 14400,
+                                "highlight": "Flash Deal: Save 10¢ per gallon",
+                                "id": "offer_testmart_001",
+                                "types": ["gasbuddy"],
+                                "use": ["banner", "strike", "sort"]
+                            }
+                        ],
+                        "payStatus": null
+                    },
+                    {
                         "address": {"country": "US", "line1": "1419 N 195th Ave", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},
                         "brands": [{"brandId": 5, "brandingType": "branded", "imageUrl": "https://images.gasbuddy.io/b/5.png", "name": "Chevron"}],
                         "distance": 1.1,

--- a/tests/fixtures/prices_gps.json
+++ b/tests/fixtures/prices_gps.json
@@ -116,7 +116,9 @@
                                 "fuelProduct": "premium_gas",
                                 "longName": "Premium"
                             }
-                        ]
+                        ],
+                        "offers": [],
+                        "payStatus": {"isPayAvailable": false}
                     },
                     {
                         "address": {"country": "US", "line1": "1419 N 195th Ave", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},

--- a/tests/fixtures/prices_gps.json
+++ b/tests/fixtures/prices_gps.json
@@ -87,7 +87,8 @@
                                 "types": ["gasbuddy"],
                                 "use": ["banner", "strike", "sort"]
                             }
-                        ]
+                        ],
+                        "payStatus": {"isPayAvailable": true}
                     },
                     {
                         "address": {"country": "US", "line1": "1101 N Verrado Way", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -692,6 +692,33 @@ async def test_price_lookup_service_name_address(mock_aioclient):
     await manager.clear_cache()
 
 
+async def test_price_lookup_service_null_pay_status_flash_deal(mock_aioclient):
+    """Null payStatus object must be treated as deal-eligible (Flash Deal stations)."""
+    mock_aioclient.get(GB_URL, status=200, body=load_fixture("index.html"), repeat=True)
+    mock_aioclient.post(TEST_URL, status=200, body=load_fixture("prices_gps.json"))
+    manager = py_gasbuddy.GasBuddy()
+    data = await manager.price_lookup_service(lat=33.465, lon=-112.505)
+
+    # TestMart (index 2) has payStatus=null and a 10¢ offer → pay_status True, deal applied
+    flash = next(r for r in data["results"] if r["station_id"] == "999001")
+    assert flash["pay_status"] is True
+    assert flash["regular_gas"]["deal_price"] == pytest.approx(3.10)
+    await manager.clear_cache()
+
+
+async def test_price_lookup_service_false_pay_status_no_deal(mock_aioclient):
+    """payStatus={isPayAvailable:false} must suppress deal pricing (e.g. Costco)."""
+    mock_aioclient.get(GB_URL, status=200, body=load_fixture("index.html"), repeat=True)
+    mock_aioclient.post(TEST_URL, status=200, body=load_fixture("prices_gps.json"))
+    manager = py_gasbuddy.GasBuddy()
+    data = await manager.price_lookup_service(lat=33.465, lon=-112.505)
+
+    costco = next(r for r in data["results"] if r["station_id"] == "208656")
+    assert costco["pay_status"] is False
+    assert costco["regular_gas"]["deal_price"] is None
+    await manager.clear_cache()
+
+
 async def test_unicode_decode_error(mock_aioclient, caplog):
     """Test UnicodeDecodeError fallback path in process_request."""
     from contextlib import asynccontextmanager


### PR DESCRIPTION
## Summary

- **Root cause**: `bool((station.get("payStatus") or {}).get("isPayAvailable", False))` treated a null `payStatus` object as `False`, suppressing deal prices for GasBuddy Flash Deal stations (Speedway, SNK, Fastrac, etc.)
- **Discovery**: Probed 5 stations — Flash Deal stations return `payStatus = null` from GraphQL; Costco returns `{isPayAvailable: false}`; Circle K returns `{isPayAvailable: true}`
- **Fix**: `pay_status = (payStatus is None) OR isPayAvailable`
  - `null` payStatus → Flash Deal station → deal pricing **enabled**
  - `{isPayAvailable: false}` → GasBuddy Pay disabled (e.g. Costco membership restriction) → **no deal**
  - `{isPayAvailable: true}` → full GasBuddy Pay → deal pricing **enabled**
- Also adds `payStatus { isPayAvailable }` to `LOCATION_QUERY_PRICES` so `price_lookup_service()` returns accurate `pay_status` (previously the field was absent from that query entirely)
- Updates `prices_gps.json` fixture to include `payStatus` for Costco station

## Test plan

- [x] All 46 unit tests pass
- [x] `ruff check` and `ruff format --check` pass
- [x] Live smoke test: Speedway (34745) shows deal prices; Costco (172725) shows no deal price

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced payment availability data retrieval to improve deal-price accuracy for gas stations.

* **Bug Fixes**
  * Corrected discount calculation logic to properly handle stations with unavailable payment methods, preventing inappropriate deal pricing.

* **Tests**
  * Added test coverage for payment status scenarios affecting deal eligibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/py-gasbuddy/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->