### PR TITLE
ci: run release drafter on pull_request_target

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

This PR fixes the `release-drafter` workflow failure on pull requests submitted from fork repositories. 

### Problem
When a contributor submits a PR from a fork, the `pull_request` event triggers a workflow with a restricted, read-only `GITHUB_TOKEN`. Because of this, the `release-drafter` action failed with a permission error since it requires write permissions (`contents: write` and `pull-requests: write`) to create/update draft releases and automatically apply labels.

### Changes
- Changed the workflow trigger from `pull_request` to `pull_request_target` in `.github/workflows/release-drafter.yml`.
- Updated the concurrency group to `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` so that concurrent workflow runs for different PRs do not conflict or cancel each other.