### PR TITLE
feat: bring location query to parity with station query

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -285,7 +285,7 @@ class GasBuddy:
             "brands": station.get("brands") or [],
             "amenities": station.get("amenities") or [],
             "hours": station.get("hours"),
-            "phone": station.get("phone"),
+            "phone": station.get("phone") or None,
             "open_status": station.get("openStatus"),
             "fuels": station.get("fuels") or [],
             "star_rating": station.get("starRating"),

--- a/py_gasbuddy/consts.py
+++ b/py_gasbuddy/consts.py
@@ -418,6 +418,15 @@ query LocationBySearchTerm(
           fuelProduct
           longName
         }
+        amenities {
+          amenityId
+          name
+        }
+        hasActiveOutage
+        hours {
+          openingHours
+          status
+        }
         offers {
           discounts {
             grades
@@ -431,9 +440,11 @@ query LocationBySearchTerm(
           types
           use
         }
+        openStatus
         payStatus {
           isPayAvailable
         }
+        phone
       }
     }
     trends {

--- a/py_gasbuddy/parsers.py
+++ b/py_gasbuddy/parsers.py
@@ -121,6 +121,11 @@ def parse_results(response: dict[str, Any], limit: int) -> list[StationPrice]:
             "star_rating": result.get("starRating"),
             "ratings_count": result.get("ratingsCount"),
             "fuels": result.get("fuels") or [],
+            "amenities": result.get("amenities") or [],
+            "has_active_outage": bool(result.get("hasActiveOutage", False)),
+            "hours": result.get("hours"),
+            "open_status": result.get("openStatus"),
+            "phone": result.get("phone") or None,
         }
         pay_status_obj = result.get("payStatus")
         is_pay_available = (pay_status_obj is None) or bool(

--- a/tests/fixtures/prices_gps.json
+++ b/tests/fixtures/prices_gps.json
@@ -209,7 +209,14 @@
                                 "fuelProduct": "diesel",
                                 "longName": "Diesel"
                             }
-                        ]
+                        ],
+                        "amenities": [{"amenityId": "pay_at_pump", "name": "Pay At Pump"}],
+                        "hasActiveOutage": false,
+                        "hours": null,
+                        "offers": [],
+                        "openStatus": "open",
+                        "payStatus": null,
+                        "phone": null
                     },
                     {
                         "address": {"country": "US", "line1": "721 N 195th Ave", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},
@@ -249,7 +256,14 @@
                                 "fuelProduct": "diesel",
                                 "longName": "Diesel"
                             }
-                        ]
+                        ],
+                        "amenities": [{"amenityId": "c_store", "name": "C-Store"}, {"amenityId": "pay_at_pump", "name": "Pay At Pump"}],
+                        "hasActiveOutage": false,
+                        "hours": {"openingHours": "Open 24 Hours", "status": "open"},
+                        "offers": [],
+                        "openStatus": "open",
+                        "payStatus": {"isPayAvailable": true},
+                        "phone": null
                     },
                     {
                         "address": {"country": "US", "line1": "19600 W Indian School Rd", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},
@@ -295,7 +309,14 @@
                                 "fuelProduct": "e85",
                                 "longName": "E85"
                             }
-                        ]
+                        ],
+                        "amenities": [{"amenityId": "pay_at_pump", "name": "Pay At Pump"}],
+                        "hasActiveOutage": false,
+                        "hours": {"openingHours": "Mon-Sun 6am-11pm", "status": "open"},
+                        "offers": [],
+                        "openStatus": "open",
+                        "payStatus": null,
+                        "phone": null
                     }
                 ]
             },

--- a/tests/fixtures/prices_gps.json
+++ b/tests/fixtures/prices_gps.json
@@ -77,18 +77,24 @@
                                 "longName": "Diesel"
                             }
                         ],
+                        "amenities": [{"amenityId": "c_store", "name": "C-Store"}, {"amenityId": "pay_at_pump", "name": "Pay At Pump"}],
+                        "hasActiveOutage": false,
+                        "hours": null,
                         "offers": [
                             {
                                 "discounts": [
                                     {"grades": ["regular_gas", "midgrade_gas", "premium_gas", "diesel"], "highlight": "Flash Deal: Save 10¢ per gallon", "pwgbDiscount": "0.10", "receiptDiscount": null}
                                 ],
+                                "duration": 14400,
                                 "highlight": "Flash Deal: Save 10¢ per gallon",
                                 "id": "offer_shell_001",
                                 "types": ["gasbuddy"],
                                 "use": ["banner", "strike", "sort"]
                             }
                         ],
-                        "payStatus": {"isPayAvailable": true}
+                        "openStatus": "open",
+                        "payStatus": {"isPayAvailable": true},
+                        "phone": "555-111-2222"
                     },
                     {
                         "address": {"country": "US", "line1": "1101 N Verrado Way", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},
@@ -117,8 +123,13 @@
                                 "longName": "Premium"
                             }
                         ],
+                        "amenities": [],
+                        "hasActiveOutage": false,
+                        "hours": {"openingHours": "Mon-Fri 10am-8:30pm, Sat 9:30am-6pm, Sun 10am-6pm", "status": "open"},
                         "offers": [],
-                        "payStatus": {"isPayAvailable": false}
+                        "openStatus": "open",
+                        "payStatus": {"isPayAvailable": false},
+                        "phone": "555-333-4444"
                     },
                     {
                         "address": {"country": "US", "line1": "100 Test Blvd", "line2": null, "locality": "Springfield", "postalCode": "62701", "region": "IL"},
@@ -141,6 +152,9 @@
                                 "longName": "Regular"
                             }
                         ],
+                        "amenities": [{"amenityId": "pay_at_pump", "name": "Pay At Pump"}],
+                        "hasActiveOutage": false,
+                        "hours": null,
                         "offers": [
                             {
                                 "discounts": [
@@ -153,7 +167,9 @@
                                 "use": ["banner", "strike", "sort"]
                             }
                         ],
-                        "payStatus": null
+                        "openStatus": "open",
+                        "payStatus": null,
+                        "phone": null
                     },
                     {
                         "address": {"country": "US", "line1": "1419 N 195th Ave", "line2": null, "locality": "Buckeye", "postalCode": "85396", "region": "AZ"},


### PR DESCRIPTION
## Summary

`price_lookup_service()` was missing several fields that `price_lookup()` already fetched for individual stations. This caused any integration using `price_lookup_service()` to have incomplete station data — for example, `open_status` would always be absent from results.

All five fields were confirmed available in `locationBySearchTerm` results via live API probing:

| Field added to query | Parsed as | Effect |
|---|---|---|
| `openStatus` | `open_status` | Station open/closed status now available in results |
| `amenities { amenityId name }` | `amenities` | Amenity list now available in results |
| `hours { openingHours status }` | `hours` | Station schedule data now available in results |
| `phone` | `phone` | Phone number now available in results |
| `hasActiveOutage` | `has_active_outage` | Active outage flag now available in results |

Empty-string `phone` values (returned by some stations) are normalized to `None`.

## Test plan

- [x] All 48 unit tests pass
- [x] `ruff check` and `ruff format --check` pass
- [x] Live probe confirmed all 5 fields available in `locationBySearchTerm` results
- [x] Fixture updated for Shell, Costco, and TestMart stations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gas stations now show amenities, operating hours/status, open status, phone numbers, payment-availability info, and active outage indicators.
* **Bug Fixes**
  * Missing phone numbers are now normalized so absent contact info is handled consistently in lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/py-gasbuddy/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->