### PR TITLE
chore: use PEP 604 union syntax in isinstance

### DIFF
--- a/py_gasbuddy/parsers.py
+++ b/py_gasbuddy/parsers.py
@@ -16,7 +16,7 @@ def parse_distance(value: Any) -> float | None:
     """Coerce distance to float, stripping any unit suffix (e.g. '0.37mi')."""
     if value is None:
         return None
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return float(value)
     stripped = "".join(c for c in str(value) if c.isdigit() or c == ".")
     try:


### PR DESCRIPTION
## Summary
- `isinstance(value, (int, float))` → `isinstance(value, int | float)` in `parsers.py:19`. Codebase requires Python >=3.13, so the union form is fine and matches modern style.

## Test plan
- [x] `pytest -q` — 48 passed.