### PR TITLE
chore: drop unused type: ignore comments

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -139,7 +139,7 @@ class GasBuddy:
                         )
                         message = {"error": message}
                         self._cf_last = False
-                    return message  # type: ignore[return-value]
+                    return message
 
             except (TimeoutError, ServerTimeoutError):
                 _LOGGER.error("%s: %s", ERROR_TIMEOUT, self._url)
@@ -148,7 +148,7 @@ class GasBuddy:
                 _LOGGER.error("%s", err)
                 message = {"error": err}
 
-        return message  # type: ignore[return-value]
+        return message
 
     @asynccontextmanager
     async def _get_session(self) -> AsyncIterator[aiohttp.ClientSession]:


### PR DESCRIPTION
## Summary
- mypy reports `[unused-ignore]` errors on `py_gasbuddy/__init__.py:142` and `:151`. With `warn_unused_ignores = true` (effectively on under strict), the `tox -e mypy` job fails.
- Remove the redundant `# type: ignore[return-value]` comments.

## Test plan
- [x] `mypy py_gasbuddy` → "Success: no issues found in 6 source files"
- [x] `pytest -q` → 48 passed