### PR TITLE
chore: truncate Non-JSON logs + drop unused consts

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -125,7 +125,18 @@ class GasBuddy:
                         message = json.loads(message)
                         self._cf_last = True
                     except ValueError:
-                        _LOGGER.warning("Non-JSON response: %s", message)
+                        # Truncate body so Cloudflare interstitial HTML
+                        # doesn't dump multi-KB pages to the HA log.
+                        truncated = (
+                            message
+                            if isinstance(message, str) and len(message) <= 500
+                            else (
+                                f"{message[:500]}... (truncated)"
+                                if isinstance(message, str)
+                                else message
+                            )
+                        )
+                        _LOGGER.warning("Non-JSON response: %s", truncated)
                         message = {"error": message}
                         self._cf_last = False
                     if response.status == 403:

--- a/py_gasbuddy/consts.py
+++ b/py_gasbuddy/consts.py
@@ -20,7 +20,6 @@ DEFAULT_HEADERS = {
 }
 
 TOKEN = "token"
-TOKEN_SKIP = "Already have token and last call was successful. Skipping token search."
 
 # Fuel product keys returned by the API in the `fuels` list and as PriceNode keys.
 FUEL_PRODUCTS: dict[str, str] = {
@@ -42,24 +41,6 @@ FUEL_FILTER_IDS: dict[str, int] = {
     "e85": 5,
     "unl88": 12,
 }
-
-EV_ALL_NETWORKS = (
-    "7Charge,ABM,AmpedUp_Networks,AmpUp,applegreen_electric,Autel,BC_Hydro,Blink,"
-    "bp_pulse,Chaevi,ChargeLab,ChargeNet,ChargePoint,ChargeSmart_EV,ChargeUP,Chargie,"
-    "CircleK_Charge,CircleK_Couche_Tard_Recharge,Circuit_electrique,DirtRoad,"
-    "eCharge_Network,Electric_Era,Electrify_America,Electrify_Canada,Enel_X_Way,"
-    "EnviroSpark,Epic_Charging,EVBOLT,EV_Connect,EVCS,EvGateway,EVgo,EVIUM_Charging,"
-    "EVmatch,Evoke_Systems,EVPassport,eVPower,EV_Range,EVXY,ezVOLTz,FLASH,Flipturn,"
-    "Flitway,FLO,Ford_Charge,FPL_EVolution,Francis_Energy,GO_TO_U,Graviti_Energy,"
-    "Gravity_Charging_Center,HoneyBadger_Charging,Hwisel,Hyperfuel,InCharge,IONNA,"
-    "Ivy,Jule,Kwik_Charge,Lakeland_EV_CHARGING,Loop,Matcha_Electric,Mercedes_Benz_HPC,"
-    "Non_Networked,Noodoe,OBE_Power,On_the_Run_EV,OpConnect,Petro_Canada,PowerCharge,"
-    "PowerFlex,PowerPort_EVC,PowerPump,QuickCharge,Red_E_Charge,Revel,"
-    "Revitalize_Charging,Rivian_Adventure_Network,Rivian_Waypoints,Rove,SemaConnect,"
-    "Shell_Recharge,Stay_N_Charge,Sun_Country_Highway,SWTCH_Energy,Tesla,"
-    "Tesla_Destination,TurnOnGreen,Universal_EV_Chargers,ViaLynk,Volta,Walmart,"
-    "WattEV,WAVE,Xeal_EV_Charging,ZEF_Network"
-)
 
 EV_CONNECTOR_TYPES = "J1772,J1772COMBO,CHADEMO,TESLA"
 


### PR DESCRIPTION
## Summary
- The `Non-JSON response` warning currently logs the entire response body. Under Cloudflare interstitials that's multi-KB HTML flooding HA logs at WARNING level. Truncate to 500 chars before logging; the full body still goes to the returned `{"error": ...}` dict.
- Delete `TOKEN_SKIP` (defined in `consts.py`, never referenced anywhere).
- Delete `EV_ALL_NETWORKS` (defined, never used internally, never imported by ha-gasbuddy).

## Test plan
- [x] `pytest -q` → 48 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging by truncating non-JSON response payloads to 500 characters, preventing oversized logs from interstitial pages.

* **Chores**
  * Removed unused internal constants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/py-gasbuddy/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->