### PR TITLE
chore: declare __all__ and prune unused requirements

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -49,6 +49,21 @@ from .parsers import (
     parse_trends,
 )
 
+__all__ = [
+    "APIError",
+    "CSRFTokenMissing",
+    "EvStation",
+    "EvStationResult",
+    "GasBuddy",
+    "GraphQLQuery",
+    "LibraryError",
+    "LocationSearchResult",
+    "MissingSearchData",
+    "PriceServiceResult",
+    "StationPrice",
+    "StationSummary",
+]
+
 ERROR_TIMEOUT = "Timeout while updating"
 CSRF_TIMEOUT = "Timeout while getting CSRF tokens"
 MAX_RETRIES = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 aiofiles
 aiohttp
 backoff
-requests

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,9 +1,4 @@
 -r requirements.txt
 ruff==0.15.14
 pre-commit==4.6.0
-black==26.5.1
-flake8==7.3.0
 mypy==2.1.0
-pydocstyle==6.3.0
-isort
-pylint==4.0.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,6 +4,5 @@ pytest==9.0.3
 pytest-cov==7.1.0
 pytest-timeout==2.4.0
 pytest-asyncio
-requests-mock
 aioresponses
 tox==4.54.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,6 @@ python =
 extras = test
 commands =
   pytest {posargs}
-deps =
-  pytest
-  pytest-cov
-  pytest-timeout
-  pytest-asyncio
-  requests-mock
-  aioresponses
-  aiofiles
-  backoff
 
 [testenv:lint]
 basepython = python3
@@ -34,6 +25,5 @@ basepython = python3
 deps =
   mypy
   aiofiles
-  types-requests
 commands =
   mypy py_gasbuddy


### PR DESCRIPTION
## Summary
- Declare `__all__` in `py_gasbuddy/__init__.py` listing the intended public surface (`GasBuddy`, the four exceptions, the TypedDict models). Documents intent for star imports and tooling without changing accessibility of internals.
- Prune unused entries from requirements files / tox.ini:
  - `requirements.txt`: drop `requests` (never imported).
  - `requirements_test.txt`: drop `requests-mock` (tests use aioresponses).
  - `tox.ini` [testenv]: drop redundant explicit deps that already come via `extras = test` and the project's runtime deps.
  - `tox.ini` [testenv:mypy]: drop `types-requests` (`requests` is gone).
  - `requirements_lint.txt`: drop `black`, `flake8`, `pydocstyle`, `isort`, `pylint` — project lints with ruff per pyproject.toml; pre-commit runs ruff only.

## Test plan
- [x] `pytest -q` → 48 passed.
- [x] `from py_gasbuddy import GasBuddy, APIError, CSRFTokenMissing, LibraryError, MissingSearchData` still works.