### PR TITLE
fix: honor timeout, validate cache shape, raise on bad CSRF

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -109,9 +109,13 @@ class GasBuddy:
         async with self._get_session() as session:
             json_query: str = json.dumps(query)
             _LOGGER.debug("URL: %s\nQuery: %s", self._url, json_query)
+            request_timeout = aiohttp.ClientTimeout(total=self._timeout / 1000)
             try:
                 async with session.post(
-                    self._url, data=json_query, headers=headers
+                    self._url,
+                    data=json_query,
+                    headers=headers,
+                    timeout=request_timeout,
                 ) as response:
                     message: dict[str, Any] | Any = {}
                     try:
@@ -572,12 +576,16 @@ class GasBuddy:
 
         _LOGGER.debug("Token invalid, getting a new one...")
 
+        csrf_timeout = aiohttp.ClientTimeout(total=self._timeout / 1000)
         async with self._get_session() as session:
             http_method = getattr(session, method)
             _LOGGER.debug("Calling %s with data: %s", url, json_data)
             try:
                 async with http_method(
-                    url, json=json_data, headers=DEFAULT_HEADERS
+                    url,
+                    json=json_data,
+                    headers=DEFAULT_HEADERS,
+                    timeout=csrf_timeout,
                 ) as response:
                     message: str = ""
                     message = await response.text()
@@ -587,7 +595,10 @@ class GasBuddy:
                             response.status,
                             message,
                         )
-                        return
+                        # Raise so callers know the token wasn't refreshed,
+                        # rather than silently proceeding to POST with an
+                        # empty/stale token (which would 403).
+                        raise CSRFTokenMissing
 
                     if self._solver:
                         message = json.loads(message)["solution"]["response"]

--- a/py_gasbuddy/cache.py
+++ b/py_gasbuddy/cache.py
@@ -47,14 +47,19 @@ class GasBuddyCache:
         return {}
 
     async def cache_exists(self) -> bool:
-        """Return bool if cache exists and contains data."""
+        """Return True if cache file holds a valid token payload."""
         check = await aiofiles.os.path.isfile(self._cache_file)
         _LOGGER.debug("Cache file exists? %s", check)
-        if check:
-            size = await aiofiles.os.path.getsize(self._cache_file)
-            _LOGGER.debug("Checking cache file size: %s", size)
-            return bool(size > 30)
-        return False
+        if not check:
+            return False
+        try:
+            async with aiofiles.open(self._cache_file) as file:
+                contents = await file.read()
+            data = json.loads(contents)
+        except (OSError, json.JSONDecodeError):
+            _LOGGER.debug("Cache file unreadable or not valid JSON")
+            return False
+        return isinstance(data, dict) and bool(data.get("token"))
 
     async def clear_cache(self) -> None:
         """Remove cache file."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -265,7 +265,10 @@ async def test_header_errors(mock_aioclient, caplog):
         body=load_fixture("station.json"),
         repeat=True,
     )
-    await py_gasbuddy.GasBuddy(station_id=205033).price_lookup()
+    # A non-200 from the CSRF endpoint must surface as a clean LibraryError
+    # rather than silently proceeding to POST with an empty token.
+    with pytest.raises(py_gasbuddy.LibraryError):
+        await py_gasbuddy.GasBuddy(station_id=205033).price_lookup()
     assert (
         "An error retrieving data from the server, code: 404\nmessage: Not Found"
         in caplog.text
@@ -453,7 +456,8 @@ async def test_cache_json_error(mock_aioclient, caplog, tmp_path):
     with caplog.at_level(logging.DEBUG):
         manager = py_gasbuddy.GasBuddy(station_id=205033, cache_file=cache_file)
         await manager.price_lookup()
-        assert "Invalid JSON data" in caplog.text
+        # cache_exists rejects the garbage file before read_cache is reached
+        assert "Cache file unreadable or not valid JSON" in caplog.text
     await manager.clear_cache()
 
 
@@ -594,6 +598,7 @@ async def test_external_session(mock_aioclient, tmp_path):
                 py_gasbuddy.BASE_URL,
                 data=mock_post.call_args.kwargs["data"],
                 headers=mock_post.call_args.kwargs["headers"],
+                timeout=mock_post.call_args.kwargs["timeout"],
             )
 
         # Session must still be open (not closed by the library)
@@ -624,7 +629,9 @@ async def test_cache_small_file(mock_aioclient, tmp_path, caplog):
     with caplog.at_level(logging.DEBUG):
         await manager.price_lookup()
 
-    assert "Checking cache file size: 19" in caplog.text
+    # Non-JSON cache content is rejected by cache_exists; library falls
+    # through to fetching a fresh token.
+    assert "Cache file unreadable or not valid JSON" in caplog.text
     assert "No cache file found, creating..." in caplog.text
 
 


### PR DESCRIPTION
## Summary

Three related bugs in the CSRF/Cloudflare path:

1. **`timeout` ctor param was a no-op for the GraphQL POST and CSRF GET.** Only `maxTimeout` for FlareSolverr was wired up. Plain `session.post` used aiohttp's default 5-minute total. HA users hitting Cloudflare blocks would see coordinators stall far past the configured 60 s. Build `aiohttp.ClientTimeout(total=self._timeout / 1000)` and pass it to both request sites.

2. **`cache_exists` validated by file size, not content.** A corrupt file >30 bytes was accepted; `read_cache` would then silently return `{}` and the next request would proceed with an empty token. Parse the file and require a dict with a non-empty `token` key.

3. **`_get_headers` returned silently on non-200.** The caller then POSTed with an empty `gbcsrf` header, which Cloudflare 403s. Raise `CSRFTokenMissing` so `process_request` returns a clean `{"error": "Missing Token"}` instead.

## Test plan
- [x] `pytest -q` → 48 passed (4 tests updated to match the new — correct — behavior).
- [x] `test_header_errors` now asserts that a 404 from the CSRF endpoint surfaces as `LibraryError` instead of silently succeeding with an empty token.

## Out of scope (follow-up PRs)
Three other items from the audit are intentionally left for a separate discussion:
- 403 path doesn't actually retry (backoff decorator never sees an exception).
- `_cf_last` flag inconsistent with response status across various paths.
- Raw `aiohttp.ClientError` can leak to callers after backoff exhausts retries.

These need a coherent retry-policy decision before code lands — happy to open follow-ups once you've had a look at this.