### PR TITLE
fix: force token refresh when cache lacks a usable token

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -555,7 +555,11 @@ class GasBuddy:
             if isinstance(cache_data, dict) and TOKEN in cache_data:
                 self._tag = cache_data[TOKEN]
             else:
+                # Cache existed but didn't contain a usable token (corrupt
+                # file, partial write, schema drift). Force a refresh so we
+                # don't POST with an empty CSRF header — that would 403.
                 self._tag = ""
+                self._cf_last = False
         else:
             _LOGGER.debug("No cache file found, creating...")
             self._cf_last = False


### PR DESCRIPTION
## Summary
- When the cache file exists but doesn't contain a usable `TOKEN` key (corrupt file, partial write, schema drift), the code sets `self._tag = ""` but leaves `self._cf_last` at its prior value. If a prior call set it to `True`, the next `_get_headers` call returns early without refreshing — and the subsequent POST goes out with an empty `gbcsrf` header, guaranteed 403.
- Also set `self._cf_last = False` in that branch so the token refresh path runs.

## Test plan
- [x] `pytest -q` → 48 passed.