### PR TITLE
feat(ev): pipe cards_accepted into EV station queries

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -406,6 +406,7 @@ class GasBuddy:
         networks: str | None = None,
         connector_types: str | None = None,
         charging_levels: str | None = None,
+        cards_accepted: str | None = None,
         access_code: str = "public",
         limit: int = 50,
     ) -> EvStationResult:
@@ -418,6 +419,8 @@ class GasBuddy:
             networks: Comma-separated network names; defaults to all known networks.
             connector_types: Comma-separated connector types (default all).
             charging_levels: Comma-separated charging levels (default all).
+            cards_accepted: Comma-separated payment cards required (e.g.
+                ``"A,V,M,D"`` for AmEx/Visa/MC/Discover); defaults to no filter.
             access_code: ``"public"`` or ``"private"`` (default ``"public"``).
             limit: Maximum stations to return (default 50).
         """
@@ -435,6 +438,8 @@ class GasBuddy:
             variables["connectorTypes"] = connector_types
         if charging_levels is not None:
             variables["chargingLevels"] = charging_levels
+        if cards_accepted is not None:
+            variables["cardsAccepted"] = cards_accepted
 
         query: GraphQLQuery = {
             "operationName": "EvStationsSearch",
@@ -474,6 +479,7 @@ class GasBuddy:
         networks: str | None = None,
         connector_types: str | None = None,
         charging_levels: str | None = None,
+        cards_accepted: str | None = None,
         access_code: str = "public",
         limit: int = 200,
     ) -> EvStationResult:
@@ -487,6 +493,8 @@ class GasBuddy:
             networks: Comma-separated network names; defaults to all known networks.
             connector_types: Comma-separated connector types (default all).
             charging_levels: Comma-separated charging levels (default all).
+            cards_accepted: Comma-separated payment cards required (e.g.
+                ``"A,V,M,D"`` for AmEx/Visa/MC/Discover); defaults to no filter.
             access_code: ``"public"`` or ``"private"`` (default ``"public"``).
             limit: Maximum stations to return (default 200).
         """
@@ -506,6 +514,8 @@ class GasBuddy:
             variables["connectorTypes"] = connector_types
         if charging_levels is not None:
             variables["chargingLevels"] = charging_levels
+        if cards_accepted is not None:
+            variables["cardsAccepted"] = cards_accepted
 
         query: GraphQLQuery = {
             "operationName": "EvStationsByBounds",


### PR DESCRIPTION
## Summary
- Both EV GraphQL queries already declare `$cardsAccepted: String` and the server accepts it. The Python wrapper just never exposed the filter — callers could *read* `cards_accepted` from parsed stations but not query on it.
- Add an optional `cards_accepted: str | None = None` parameter to `ev_stations_nearby` and `ev_stations_by_bounds`. When provided, it's threaded into the `cardsAccepted` GraphQL variable.

## Test plan
- [x] `pytest -q` → 48 passed.
- Manual: passing `cards_accepted="V,M"` returns only stations accepting Visa/MC.