### PR TITLE
fix: real Cloudflare retry, unified _cf_last, no ClientError leak

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -107,11 +107,37 @@ class GasBuddy:
         self._timeout = timeout
         self._session = session
 
-    @backoff.on_exception(
-        backoff.expo, aiohttp.ClientError, max_time=60, max_tries=MAX_RETRIES
-    )
     async def process_request(self, query: GraphQLQuery) -> dict[str, Any]:
-        """Process API requests."""
+        """Process API requests.
+
+        Retries up to MAX_RETRIES times on transient `aiohttp.ClientError`
+        (including Cloudflare 403 challenges — see `_do_request`). On
+        exhaustion, returns a `{"error": ...}` dict so callers always see
+        the library's standard error envelope rather than a leaked
+        `aiohttp.ClientError`.
+        """
+        result = await self._do_request(query)
+        if result is None:
+            _LOGGER.error("Request retries exhausted")
+            return {"error": "Retries exhausted"}
+        return result
+
+    @backoff.on_exception(
+        backoff.expo,
+        aiohttp.ClientError,
+        max_time=60,
+        max_tries=MAX_RETRIES,
+        raise_on_giveup=False,
+    )
+    async def _do_request(self, query: GraphQLQuery) -> dict[str, Any] | None:
+        """Single HTTP attempt at the GraphQL POST.
+
+        Wrapped by backoff in `process_request`. May raise
+        `aiohttp.ClientError` to signal a retryable failure (Cloudflare
+        403, network error). When backoff's retry budget is exhausted,
+        the decorator returns `None` (because of `raise_on_giveup=False`)
+        and `process_request` converts that to an error dict.
+        """
         headers = dict(DEFAULT_HEADERS)
         try:
             await self._get_headers()
@@ -124,46 +150,98 @@ class GasBuddy:
         async with self._get_session() as session:
             json_query: str = json.dumps(query)
             _LOGGER.debug("URL: %s\nQuery: %s", self._url, json_query)
+            request_timeout = aiohttp.ClientTimeout(total=self._timeout / 1000)
             try:
                 async with session.post(
-                    self._url, data=json_query, headers=headers
+                    self._url,
+                    data=json_query,
+                    headers=headers,
+                    timeout=request_timeout,
                 ) as response:
-                    message: dict[str, Any] | Any = {}
-                    try:
-                        message = await response.text()
-                    except UnicodeDecodeError:
-                        _LOGGER.debug("Decoding error.")
-                        data = await response.read()
-                        message = data.decode(errors="replace")
-
-                    try:
-                        message = json.loads(message)
-                        self._cf_last = True
-                    except ValueError:
-                        _LOGGER.warning("Non-JSON response: %s", message)
-                        message = {"error": message}
-                        self._cf_last = False
-                    if response.status == 403:
-                        _LOGGER.debug("Retrying request...")
-                        self._cf_last = False
-                    elif response.status != 200:
-                        _LOGGER.error(
-                            "An error retrieving data from the server, code: %s\nmessage: %s",  # noqa: E501
-                            response.status,
-                            message,
-                        )
-                        message = {"error": message}
-                        self._cf_last = False
-                    return message
+                    return await self._handle_response(response)
 
             except (TimeoutError, ServerTimeoutError):
                 _LOGGER.error("%s: %s", ERROR_TIMEOUT, self._url)
-                message = {"error": ERROR_TIMEOUT}
+                self._cf_last = False
+                return {"error": ERROR_TIMEOUT}
             except ContentTypeError as err:
                 _LOGGER.error("%s", err)
-                message = {"error": err}
+                # Preserve the exception object in the error envelope so
+                # callers introspecting the response see structured data
+                # rather than a string repr.
+                return {"error": err}
 
-        return message
+    async def _handle_response(
+        self, response: aiohttp.ClientResponse
+    ) -> dict[str, Any]:
+        """Parse a GraphQL POST response and update auth state.
+
+        `_cf_last` policy (unified):
+        - 401/403 → False, clear cache, raise `ClientResponseError` so
+          backoff retries with a fresh CSRF token next pass.
+        - 200 + valid JSON → True (request authenticated and parsed).
+        - 200 + non-JSON (Cloudflare interstitial) → False.
+        - Other 4xx/5xx → leave `_cf_last` alone (server-side, not
+          auth-related).
+        """
+        # Read the body (handles UnicodeDecodeError defensively).
+        try:
+            body_text = await response.text()
+        except UnicodeDecodeError:
+            _LOGGER.debug("Decoding error.")
+            body_text = (await response.read()).decode(errors="replace")
+
+        # 401/403 — token-suspect. Invalidate, clear cache, raise to
+        # trigger backoff retry with a fresh token next attempt.
+        if response.status in (401, 403):
+            self._cf_last = False
+            self._tag = ""
+            if self._cache_manager is not None:
+                await self._cache_manager.clear_cache()
+            _LOGGER.warning(
+                "%d from %s — invalidating CSRF token and retrying",
+                response.status,
+                self._url,
+            )
+            raise aiohttp.ClientResponseError(
+                request_info=response.request_info,
+                history=response.history,
+                status=response.status,
+                message="Cloudflare/auth challenge",
+                headers=response.headers,
+            )
+
+        # Try to parse JSON.
+        message: Any
+        try:
+            message = json.loads(body_text)
+        except ValueError:
+            # Non-JSON body (HTML Cloudflare interstitial / plain-text
+            # server error). Truncate before logging so we don't dump
+            # multi-KB pages at WARNING.
+            truncated = (
+                body_text
+                if len(body_text) <= 500
+                else f"{body_text[:500]}... (truncated)"
+            )
+            _LOGGER.warning("Non-JSON response: %s", truncated)
+            message = {"error": body_text}
+            self._cf_last = False
+        else:
+            if response.status == 200:
+                self._cf_last = True
+
+        if response.status != 200:
+            _LOGGER.error(
+                "An error retrieving data from the server, code: %s\nmessage: %s",  # noqa: E501
+                response.status,
+                message,
+            )
+            message = {"error": message}
+            # Server-side error (not 401/403, already handled above) —
+            # don't penalise the cached token.
+
+        return cast(dict[str, Any], message)
 
     @asynccontextmanager
     async def _get_session(self) -> AsyncIterator[aiohttp.ClientSession]:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -297,7 +297,9 @@ async def test_header_errors(mock_aioclient, caplog):
 
 
 async def test_retry_logic(mock_aioclient, caplog):
-    """Test retry logic."""
+    """Test retry logic — 403 triggers backoff retry and eventually LibraryError."""
+    from unittest.mock import AsyncMock, patch
+
     mock_aioclient.get(
         GB_URL,
         status=200,
@@ -313,11 +315,38 @@ async def test_retry_logic(mock_aioclient, caplog):
         ),
         repeat=True,
     )
-    with caplog.at_level(logging.DEBUG):
+    # Patch asyncio.sleep used by backoff so the test doesn't actually
+    # wait through the exponential delay between retries.
+    with caplog.at_level(logging.DEBUG), patch("backoff._async.asyncio.sleep", new=AsyncMock()):
         with pytest.raises(py_gasbuddy.LibraryError):
             manager = py_gasbuddy.GasBuddy(station_id=205033)
             await manager.price_lookup()
-    assert "Retrying request..." in caplog.text
+    # The 403 path now raises ClientResponseError so backoff actually
+    # retries. We should see the invalidation warning more than once.
+    assert caplog.text.count("invalidating CSRF token and retrying") >= 2
+    assert "Retries exhausted" in caplog.text
+    await manager.clear_cache()
+
+
+async def test_retry_succeeds_on_second_attempt(mock_aioclient, caplog):
+    """403 once, success second time — backoff should retry and succeed."""
+    from unittest.mock import AsyncMock, patch
+
+    mock_aioclient.get(GB_URL, status=200, body=load_fixture("index.html"), repeat=True)
+    # First POST returns 403 with Cloudflare HTML, second returns valid data.
+    mock_aioclient.post(
+        TEST_URL,
+        status=403,
+        body='<!DOCTYPE html><html><title>Just a moment...</title></html>',
+    )
+    mock_aioclient.post(TEST_URL, status=200, body=load_fixture("station.json"))
+
+    with caplog.at_level(logging.DEBUG), patch("backoff._async.asyncio.sleep", new=AsyncMock()):
+        manager = py_gasbuddy.GasBuddy(station_id=205033)
+        data = await manager.price_lookup()
+
+    assert data["station_id"] == "205033"
+    assert "invalidating CSRF token and retrying" in caplog.text
     await manager.clear_cache()
 
 
@@ -594,6 +623,7 @@ async def test_external_session(mock_aioclient, tmp_path):
                 py_gasbuddy.BASE_URL,
                 data=mock_post.call_args.kwargs["data"],
                 headers=mock_post.call_args.kwargs["headers"],
+                timeout=mock_post.call_args.kwargs["timeout"],
             )
 
         # Session must still be open (not closed by the library)


### PR DESCRIPTION
## Summary

The deferred follow-up bundle from PR #253 — three intertwined retry/auth bugs that needed a coherent design before shipping.

1. **403 didn't actually retry.** Logged "Retrying request..." and set `_cf_last = False`, then returned. `@backoff.on_exception` never saw an exception, so 5-retry budget went unused. **Fix:** on 401/403 invalidate token + clear cache + raise `aiohttp.ClientResponseError` → backoff retries with a fresh CSRF token next pass.
2. **`_cf_last` semantics were inconsistent.** Multiple write sites under different branches produced confusing combinations. **Fix:** single rule in `_handle_response` — 401/403 raises (after False); 200 + JSON → True; 200 + non-JSON → False; other 4xx/5xx leave the flag alone (server-side, not auth-related).
3. **Raw `aiohttp.ClientError` could leak past `process_request`.** With (1) making ClientError normal and `max_tries=5`, exhaustion is a real failure mode and callers would crash on `response.get(...)`. **Fix:** `raise_on_giveup=False` on a new `_do_request` inner method; `process_request` converts `None` to `{"error": "Retries exhausted"}`.

Plus small folded-in items:
- Body extracted into `_do_request` + `_handle_response` for readability.
- `timeout` constructor param now passed to `session.post` via `aiohttp.ClientTimeout` (was a no-op).

## Test plan
- [x] `pytest -q` → 49 passed (1 new test).
- [x] `mypy py_gasbuddy` → no issues.
- New `test_retry_succeeds_on_second_attempt` proves 403→200 path.
- `test_retry_logic` updated to assert backoff actually retries multiple times and exhaustion returns the standard error envelope. Patches `backoff._async.asyncio.sleep` so the test runs in milliseconds.

## Notes
The 5xx case intentionally leaves `_cf_last` alone — these are server-side failures, not auth challenges, so blowing away the cached token on every 504 is wasteful. This is a deliberate behavior change called out in the audit.