### PR TITLE
feat: CloudflareBlocked exception for CSRF/Cloudflare blocks

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -25,7 +25,13 @@ from .consts import (
     LOCATION_QUERY_PRICES,
     TOKEN,
 )
-from .exceptions import APIError, CSRFTokenMissing, LibraryError, MissingSearchData
+from .exceptions import (
+    APIError,
+    CloudflareBlocked,
+    CSRFTokenMissing,
+    LibraryError,
+    MissingSearchData,
+)
 from .models import (
     EvStation as EvStation,
 )
@@ -52,6 +58,7 @@ from .parsers import (
 __all__ = [
     "APIError",
     "CSRFTokenMissing",
+    "CloudflareBlocked",
     "EvStation",
     "EvStationResult",
     "GasBuddy",
@@ -66,9 +73,27 @@ __all__ = [
 
 ERROR_TIMEOUT = "Timeout while updating"
 CSRF_TIMEOUT = "Timeout while getting CSRF tokens"
+# The sentinel value process_request returns in its error envelope when
+# the CSRF token fetch failed (Cloudflare interstitial, no FlareSolverr,
+# etc.). Callers can pattern-match this, but the preferred way to detect
+# CSRF/Cloudflare blocks is to catch CloudflareBlocked at the public API
+# methods (price_lookup, location_search, ev_stations_nearby, ...).
+ERROR_MISSING_TOKEN = "Missing Token"  # noqa: S105 - not a secret, error sentinel
 MAX_RETRIES = 5
 _LOGGER = logging.getLogger(__name__)
 CSRF_PATTERN = re.compile(r'window\.gbcsrf\s*=\s*(["])(.*?)\1')
+
+
+def _raise_library_error(message: Any) -> None:
+    """Raise the right library exception for a process_request error.
+
+    Routes the well-known CSRF/Cloudflare sentinel to the dedicated
+    ``CloudflareBlocked`` subclass and everything else to the generic
+    ``LibraryError`` — both carry ``message`` as the first arg.
+    """
+    if message == ERROR_MISSING_TOKEN:
+        raise CloudflareBlocked(message)
+    raise LibraryError(message)
 
 
 class GasBuddy:
@@ -117,7 +142,7 @@ class GasBuddy:
             await self._get_headers()
         except CSRFTokenMissing:
             _LOGGER.error("Skipping request due to missing token.")
-            return {"error": "Missing Token"}
+            return {"error": ERROR_MISSING_TOKEN}
 
         headers["gbcsrf"] = self._tag
 
@@ -267,7 +292,7 @@ class GasBuddy:
                 "An error occurred attempting to retrieve the data: %s",
                 message,
             )
-            raise LibraryError
+            _raise_library_error(message)
         if "errors" in response.keys():
             try:
                 message = response["errors"]["message"]
@@ -385,7 +410,7 @@ class GasBuddy:
                 "An error occurred attempting to retrieve the data: %s",
                 message,
             )
-            raise LibraryError
+            _raise_library_error(message)
         if "errors" in response.keys():
             try:
                 message = response["errors"]["message"]
@@ -463,7 +488,7 @@ class GasBuddy:
                 "An error occurred attempting to retrieve EV station data: %s",
                 response["error"],
             )
-            raise LibraryError
+            _raise_library_error(response["error"])
         if "errors" in response:
             try:
                 message = response["errors"][0]["message"]
@@ -534,7 +559,7 @@ class GasBuddy:
                 "An error occurred attempting to retrieve EV station data: %s",
                 response["error"],
             )
-            raise LibraryError
+            _raise_library_error(response["error"])
         if "errors" in response:
             try:
                 message = response["errors"][0]["message"]

--- a/py_gasbuddy/exceptions.py
+++ b/py_gasbuddy/exceptions.py
@@ -9,6 +9,17 @@ class LibraryError(Exception):
     """Exception for a general library failure."""
 
 
+class CloudflareBlocked(LibraryError):
+    """Cloudflare blocked the CSRF/token-fetch round-trip.
+
+    Subclass of :class:`LibraryError`, so existing ``except LibraryError``
+    clauses still match. Catch this directly to distinguish a
+    CSRF/Cloudflare block (typically remedied by configuring
+    FlareSolverr) from other library failures such as invalid station
+    IDs or GraphQL errors returned by the server.
+    """
+
+
 class APIError(Exception):
     """Exception for a GraphQL API error returned by the server."""
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -288,11 +288,29 @@ async def test_header_errors(mock_aioclient, caplog):
         body="<html></html>",
     )
     with caplog.at_level(logging.DEBUG):
-        with pytest.raises(py_gasbuddy.LibraryError):
+        # CloudflareBlocked is a LibraryError subclass; we assert the
+        # specific type here and the subclass relationship in a
+        # dedicated test below.
+        with pytest.raises(py_gasbuddy.CloudflareBlocked):
             manager = py_gasbuddy.GasBuddy(station_id=205033)
             await manager.price_lookup()
     assert "CSRF token not found." in caplog.text
     assert "Skipping request due to missing token." in caplog.text
+    await manager.clear_cache()
+
+
+async def test_csrf_block_raises_cloudflare_blocked(mock_aioclient):
+    """A failed CSRF fetch surfaces as CloudflareBlocked (a LibraryError)."""
+    # GET /home returns HTML with no gbcsrf token → CSRFTokenMissing
+    # inside _get_headers → process_request returns the error envelope.
+    mock_aioclient.get(GB_URL, status=200, body="<html></html>", repeat=True)
+    manager = py_gasbuddy.GasBuddy(station_id=205033)
+    with pytest.raises(py_gasbuddy.CloudflareBlocked) as exc_info:
+        await manager.price_lookup()
+    # Subclass relationship — existing except-LibraryError handlers
+    # still catch it, but callers can also catch this specifically.
+    assert isinstance(exc_info.value, py_gasbuddy.LibraryError)
+    assert "Missing Token" in str(exc_info.value)
     await manager.clear_cache()
 
 


### PR DESCRIPTION
## Summary
A small public-API addition so downstream callers (ha-gasbuddy in particular) can detect a CSRF/Cloudflare block cleanly without poking private state.

- New `CloudflareBlocked(LibraryError)` exception in `exceptions.py`. Subclass of `LibraryError` → existing `except LibraryError` handlers keep working; new code can catch the specific subclass.
- Extract `ERROR_MISSING_TOKEN` constant (the literal `process_request` returns when CSRFTokenMissing is swallowed).
- Add `_raise_library_error()` helper that routes `Missing Token` → CloudflareBlocked, anything else → LibraryError. Both now carry the message as `args[0]` (currently raised bare).
- Wire into the four caller sites: `price_lookup`, `price_lookup_service`, `ev_stations_nearby`, `ev_stations_by_bounds`.
- Export via `__all__`.

## Context

Came out of the review on firstof9/ha-gasbuddy#259, where the CSRF-block detection was using substring matching on a wrapped exception that carried no message. With this exception in place, ha-gasbuddy can switch to:

```python
try:
    await gb.price_lookup()
except CloudflareBlocked:
    raise CloudflareBlockedInHA
except (APIError, LibraryError):
    # other failures
```

## Test plan
- [x] `pytest -q` → 49 passed (existing CSRF test updated to assert the subclass; new `test_csrf_block_raises_cloudflare_blocked` covers `isinstance(exc, LibraryError)` and the message arg).
- [x] `mypy py_gasbuddy` → no issues.
- [x] `ruff check` → clean.

## Backward compatibility
The four caller sites previously did `raise LibraryError` with no args. The new behavior raises the same class (or a subclass) with the error message as `args[0]` — callers that only check the exception type are unaffected; callers that read `str(err)` now get the actual error context (which they should have all along).