### PR TITLE
docs: add AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,171 @@
+# AGENTS.md
+
+A short orientation for AI coding agents (Claude, Codex, Copilot, etc.)
+working in this repo. For human contributor guidelines see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## What this repo is
+
+A Python wrapper around GasBuddy's GraphQL API. Used by
+[ha-gasbuddy](https://github.com/firstof9/ha-gasbuddy) as the upstream
+client; designed to be usable standalone too. The library handles the
+Cloudflare CSRF dance, optional FlareSolverr proxying, and a small
+on-disk token cache.
+
+```
+py_gasbuddy/
+├── __init__.py        # GasBuddy class + process_request retry loop
+├── consts.py          # GraphQL queries + constants (FUEL_*, EV_*, headers)
+├── exceptions.py      # LibraryError, APIError, CSRFTokenMissing, MissingSearchData
+├── cache.py           # GasBuddyCache (aiofiles-backed)
+├── parsers.py         # GraphQL response → TypedDict shaping
+└── models.py          # TypedDict types
+```
+
+## Environment + toolchain
+
+- **Python**: `requires-python = ">=3.13"`. CI matrix is 3.13 + 3.14.
+- **Linting**: ruff (pinned in `.pre-commit-config.yaml`). Match the
+  pre-commit version locally — newer ruff often emits noise warnings
+  that aren't gated by CI.
+- **Type checking**: `mypy` (strict mode via `tox -e mypy`). The
+  codebase is fully typed, including TypedDicts for GraphQL responses.
+- **Tests**: `pytest` + `pytest-asyncio` + `aioresponses`. The full
+  suite is ~49 tests and runs in under 0.3s.
+
+```bash
+uv venv --python 3.13
+uv pip install -e ".[test]"
+.venv/bin/python -m pytest -q
+.venv/bin/python -m mypy py_gasbuddy
+```
+
+## Architectural notes that won't be obvious from the code
+
+### The CSRF/Cloudflare flow
+
+GasBuddy's GraphQL endpoint requires a `gbcsrf` HTTP header. The value
+is extracted from a `window.gbcsrf = "..."` JS snippet on
+`https://www.gasbuddy.com/home`. Three things to know:
+
+1. **Cloudflare often blocks the GET /home.** The optional `solver_url`
+   lets users proxy through [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)
+   to bypass.
+2. **Tokens are cached on disk** so we don't refetch on every call.
+   `GasBuddyCache` persists `{"token": "..."}` JSON to a path chosen
+   by the caller (or `~/.cache/py_gasbuddy/token` by default).
+3. **`_get_headers` is the entry point** for the CSRF dance. It reads
+   the cache, falls back to fetching if `_cf_last` says the cached
+   token is stale, and raises `CSRFTokenMissing` when the fetch
+   returns HTML without a token.
+
+### `_cf_last` is the auth sentinel
+
+Three states, all meaningful:
+
+- `None` — never made a request yet
+- `True` — last GraphQL POST succeeded with a 200 + valid JSON
+- `False` — last attempt failed in a way that suggests the token is
+  bad (403, non-JSON 200, CSRF fetch failure)
+
+Subsequent calls inspect this to decide whether to refresh the token.
+Downstream callers (e.g. ha-gasbuddy) inspect it to distinguish
+"CSRF/Cloudflare block" from "GasBuddy returned an error". A public
+`CloudflareBlocked` exception is being added to make this
+distinguishability official — see #258.
+
+### `process_request` error envelope
+
+`process_request` always returns a `dict`. On failure it returns a
+single-key dict:
+
+```python
+{"error": "Missing Token"}       # CSRF fetch failed
+{"error": "Timeout while updating"}  # aiohttp timeout
+{"error": <body_str>}             # non-JSON 200 (Cloudflare interstitial)
+{"error": <ContentTypeError>}     # aiohttp ContentTypeError
+{"error": <parsed_json>}          # 4xx/5xx with JSON body
+```
+
+Callers (`price_lookup`, `location_search`, etc.) check
+`"error" in response` and raise `LibraryError(message)` (or
+`CloudflareBlocked(message)` for the `"Missing Token"` case, once
+#258 lands). Callers check `"errors" in response` for GraphQL-level
+errors and raise `APIError`.
+
+### Retry / backoff
+
+`process_request` is decorated with `@backoff.on_exception` against
+`aiohttp.ClientError`. Network errors retry with exponential delay.
+Currently a 403 from the GraphQL endpoint **doesn't trigger backoff**
+because the code returns the response normally instead of raising —
+PR #257 is in flight to fix that.
+
+When you add tests that exercise the retry path, patch
+`backoff._async.asyncio.sleep` with `AsyncMock()`, otherwise the test
+takes 30+ seconds because backoff sleeps for real:
+
+```python
+from unittest.mock import AsyncMock, patch
+with patch("backoff._async.asyncio.sleep", new=AsyncMock()):
+    ...
+```
+
+### Test mocking convention
+
+Tests use `aioresponses` to mock the HTTP layer — both the GET on
+`gasbuddy.com/home` (for CSRF) and the POST on `/graphql`. **Do not
+mock at the `GasBuddy.method` level** unless you have a reason; the
+HTTP-level mocks exercise more of the real code path.
+
+Common helpers: `tests/common.py` has `load_fixture()`; fixtures are
+plain JSON / HTML files under `tests/fixtures/`.
+
+### Public API surface
+
+`__all__` in `__init__.py` is the source of truth for what's public.
+Currently:
+
+- `GasBuddy` (the main class)
+- The four exceptions: `APIError`, `CSRFTokenMissing`, `LibraryError`,
+  `MissingSearchData` (and `CloudflareBlocked` once #258 lands)
+- The TypedDict models: `EvStation`, `EvStationResult`, `GraphQLQuery`,
+  `LocationSearchResult`, `PriceServiceResult`, `StationPrice`,
+  `StationSummary`
+
+Importing from `py_gasbuddy.consts` is technically internal but used
+by callers who need access to the GraphQL query strings. Treat as a
+soft public API and avoid breaking changes there.
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tests hang for 30+ seconds | Backoff is actually sleeping | Patch `backoff._async.asyncio.sleep` |
+| `S105: hardcoded password` on `ERROR_MISSING_TOKEN = "Missing Token"` | Ruff thinks "token" is a secret | `# noqa: S105` is the convention |
+| `unused-ignore` mypy errors | An old `# type: ignore[...]` is no longer needed | Just remove the ignore |
+| Test fails with `"data"` KeyError | `response["data"]["..."]["..."]` chain assumes well-formed GraphQL | Use `.get()` chains; partial GraphQL responses are valid |
+| Cache file gets corrupted under concurrent writes | `write_cache` isn't atomic | PR #256 in flight: tempfile + `os.replace` |
+| 403 from GraphQL doesn't trigger retry | `process_request` returns the response instead of raising | PR #257 in flight: raise `aiohttp.ClientResponseError` to trigger backoff |
+
+## When you change the public surface
+
+- **New exception**: define in `exceptions.py`, import + export via
+  `__all__` in `__init__.py`. Inherit from `LibraryError` if it's a
+  refinement of "library failure" so existing `except LibraryError`
+  handlers keep working.
+- **New GraphQL query**: define in `consts.py` as a module constant.
+  Add a corresponding method to `GasBuddy`. Add response-shape tests
+  with a fixture file under `tests/fixtures/`.
+- **New TypedDict**: define in `models.py`. If it's user-facing, add
+  to `__all__`.
+- **Behavior change in `process_request`**: this is the highest-risk
+  area. Update tests in `tests/test_init.py` and write new ones
+  covering the changed branches. Confirm `_cf_last` ends in the
+  semantically-correct state for each path.
+
+## Releases
+
+The maintainer publishes releases via GitHub Releases with
+auto-drafted release notes. `setuptools-scm` computes the version
+from the latest tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to py-gasbuddy
+
+Thanks for considering a contribution! This library is a thin async
+wrapper around GasBuddy's GraphQL API and is used as the upstream
+client for [ha-gasbuddy](https://github.com/firstof9/ha-gasbuddy)
+(among others).
+
+> AI coding agents: also read [AGENTS.md](AGENTS.md), which covers
+> repo-specific conventions in more detail than this file.
+
+## Getting started
+
+```bash
+git clone https://github.com/firstof9/py-gasbuddy
+cd py-gasbuddy
+
+# Python 3.13 or 3.14
+uv venv --python 3.13
+source .venv/bin/activate
+uv pip install -e ".[test]"
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+## Running tests
+
+```bash
+# Full suite (~0.3s)
+pytest -q
+
+# With coverage
+pytest --cov=py_gasbuddy --cov-report=term-missing
+
+# Across both supported Python versions
+tox
+```
+
+`tox` also runs the `lint` and `mypy` environments — useful before
+opening a PR.
+
+## Linting + formatting + types
+
+```bash
+pre-commit run --all-files
+.venv/bin/python -m mypy py_gasbuddy
+```
+
+The project uses **ruff** for linting + formatting (config in
+`pyproject.toml`) and **mypy** for type checking. The codebase is
+fully typed; new code should be too. If you're adding a TypedDict for
+a GraphQL response, define it in `models.py`.
+
+### A note on tests + backoff
+
+Anything that exercises the retry path will, by default, actually
+sleep through backoff's exponential delays. Patch
+`backoff._async.asyncio.sleep` to keep the test fast:
+
+```python
+from unittest.mock import AsyncMock, patch
+with patch("backoff._async.asyncio.sleep", new=AsyncMock()):
+    await manager.price_lookup()
+```
+
+## Pull requests
+
+1. **Branch from `main`** (`git checkout -b fix/short-description`).
+2. **Keep PRs small and focused.** Big "polish bundles" are harder to
+   review and revert. The retry path (`process_request` +
+   `_get_headers` + `_cf_last`) in particular has subtle invariants —
+   touch it in small steps with thorough tests.
+3. **Run the full suite + mypy + ruff before pushing.** CI runs all
+   three.
+4. **Add tests** for new behavior. Mock the HTTP layer with
+   `aioresponses`, not the `GasBuddy.method` level. Use
+   `tests/common.py:load_fixture()` for JSON/HTML responses; put new
+   fixtures under `tests/fixtures/`.
+5. **Document any public API changes**: `__all__` in `__init__.py` is
+   the source of truth for what's public. Adding a new exception?
+   Inherit from `LibraryError` if it's a refinement so existing
+   handlers keep working.
+6. **Reference the issue** if there is one (`Fixes #123`).
+
+## Backward compatibility
+
+This library is consumed by ha-gasbuddy and any other GasBuddy
+clients out there. Be deliberate about:
+
+- **Renaming or removing public functions / classes / TypedDict
+  fields.** Add deprecations + a release before removing.
+- **Changing exception types raised by public methods.** A subclass
+  of the existing type is fine (`except LibraryError` still catches
+  a `CloudflareBlocked`); a sibling is a breaking change.
+- **Changing the error-envelope dict shape returned by
+  `process_request`.** Callers may pattern-match the keys.
+
+When in doubt, open an issue first to discuss.
+
+## Reporting bugs
+
+Use the [issue tracker](https://github.com/firstof9/py-gasbuddy/issues).
+Useful information:
+
+- py-gasbuddy version (`pip show py_gasbuddy`)
+- Python version
+- Whether you're using FlareSolverr (and if so, the version)
+- A minimal reproducer if possible
+- Debug-level logs (set `py_gasbuddy` to debug)
+
+## Releases
+
+The maintainer publishes releases via GitHub Releases.
+`setuptools-scm` computes the version from the latest git tag, and
+release notes are auto-drafted by Release Drafter.
+
+## License
+
+By contributing you agree your changes are licensed under the
+project's existing license (see `LICENSE`).


### PR DESCRIPTION
## Summary

Adds two docs to capture conventions an outside contributor would otherwise have to learn from the code:

- **CONTRIBUTING.md** — human-facing: env setup with `uv`, running `pytest`/`mypy`/`tox`, PR checklist, backward-compat notes for the public API, the backoff-sleep testing trick.
- **AGENTS.md** — orientation for AI coding agents (Claude / Codex / Copilot). Covers the same conventions plus tribal knowledge:
  - The CSRF/Cloudflare flow (`_get_headers` → `process_request`) and how FlareSolverr fits in
  - What each value of `_cf_last` means (`None` / `True` / `False`)
  - The `process_request` error-envelope contract
  - Test-mocking convention: mock HTTP via `aioresponses`, not at `GasBuddy.method` level
  - `__all__` as the source of truth for the public API
  - Common pitfalls table (S105 on `ERROR_MISSING_TOKEN`, unused-ignore mypy errors, etc.)
  - Pointers to in-flight PRs that change adjacent behavior (#257, #258)

Feel free to push back on anything that misrepresents the project's actual conventions — these are based on what I observed while working on the recent PR batch, not on a project-policy doc that doesn't exist yet.

## Test plan
- [x] `pytest -q` → 49 passed (no code changes)
- [x] Markdown renders correctly in GitHub preview