### PR TITLE
refactor: replace aioresponses with custom aiohttp ClientSession mock in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ py_gasbuddy/
   that aren't gated by CI.
 - **Type checking**: `mypy` (strict mode via `tox -e mypy`). The
   codebase is fully typed, including TypedDicts for GraphQL responses.
-- **Tests**: `pytest` + `pytest-asyncio` + `aioresponses`. The full
-  suite is ~49 tests and runs in under 0.3s.
+- **Tests**: `pytest` + `pytest-asyncio` + custom `aiohttp` mock. The full
+  suite is ~73 tests and runs in under 0.3s.
 
 ```bash
 uv venv --python 3.13
@@ -113,7 +113,7 @@ with patch("backoff._async.asyncio.sleep", new=AsyncMock()):
 
 ### Test mocking convention
 
-Tests use `aioresponses` to mock the HTTP layer — both the GET on
+Tests use a custom `AiohttpClientMock` (in `tests/conftest.py` via the `mock_aioclient` fixture) to mock the HTTP layer — both the GET on
 `gasbuddy.com/home` (for CSRF) and the POST on `/graphql`. **Do not
 mock at the `GasBuddy.method` level** unless you have a reason; the
 HTTP-level mocks exercise more of the real code path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,8 @@ with patch("backoff._async.asyncio.sleep", new=AsyncMock()):
    touch it in small steps with thorough tests.
 3. **Run the full suite + mypy + ruff before pushing.** CI runs all
    three.
-4. **Add tests** for new behavior. Mock the HTTP layer with
-   `aioresponses`, not the `GasBuddy.method` level. Use
+4. **Add tests** for new behavior. Mock the HTTP layer with the
+   custom `mock_aioclient` fixture, not the `GasBuddy.method` level. Use
    `tests/common.py:load_fixture()` for JSON/HTML responses; put new
    fixtures under `tests/fixtures/`.
 5. **Document any public API changes**: `__all__` in `__init__.py` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "aioresponses",
     "pre-commit",
     "pytest",
     "pytest-asyncio",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,4 @@ pytest==9.0.3
 pytest-cov==7.1.0
 pytest-timeout==2.4.0
 pytest-asyncio
-aioresponses
 tox==4.55.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,4 @@ pytest==9.0.3
 pytest-cov==7.1.0
 pytest-timeout==2.4.0
 pytest-asyncio
-aioresponses
 tox==4.54.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,9 @@ import os
 import shutil
 import tempfile
 from collections import defaultdict
+from collections.abc import Callable, Generator
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import aiohttp
@@ -21,9 +23,9 @@ _DEFAULT_CACHE = Path.home() / ".cache" / "py_gasbuddy" / "token"
 class MockRequestCall:
     """Represent a recorded mock request call."""
 
-    def __init__(self, args, kwargs):
-        self.args = args
-        self.kwargs = kwargs
+    def __init__(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        self.args: tuple[Any, ...] = args
+        self.kwargs: dict[str, Any] = kwargs
 
 
 class MockResponse:
@@ -31,23 +33,23 @@ class MockResponse:
 
     def __init__(
         self,
-        method,
-        url,
-        status=200,
-        body=None,
-        exception=None,
-        repeat=False,
-        headers=None,
-    ):
-        self.method = method.upper()
-        self.url = URL(url)
-        self.status = status
-        self.body = body
-        self.exception = exception
-        self.repeat = repeat
-        self.headers = headers or {}
+        method: str,
+        url: str | URL,
+        status: int = 200,
+        body: str | bytes | dict[str, Any] | None = None,
+        exception: type[BaseException] | BaseException | None = None,
+        repeat: bool = False,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.method: str = method.upper()
+        self.url: URL = URL(url)
+        self.status: int = status
+        self.body: str | bytes | dict[str, Any] | None = body
+        self.exception: type[BaseException] | BaseException | None = exception
+        self.repeat: bool = repeat
+        self.headers: dict[str, str] = headers or {}
 
-    def matches(self, method, url):
+    def matches(self, method: str, url: str | URL) -> bool:
         """Check if request method and url match the mocked response."""
         return self.method == method.upper() and self.url == URL(url)
 
@@ -55,16 +57,26 @@ class MockResponse:
 class MockClientResponse:
     """Mock aiohttp.ClientResponse."""
 
-    def __init__(self, method, url, status, body, headers=None):
-        self.status = status
-        self.headers = CIMultiDictProxy(CIMultiDict(headers or {}))
-        self.request_info = aiohttp.RequestInfo(
+    def __init__(
+        self,
+        method: str,
+        url: str | URL,
+        status: int,
+        body: str | bytes | dict[str, Any] | None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status: int = status
+        self.headers: CIMultiDictProxy[str] = CIMultiDictProxy(
+            CIMultiDict(headers or {})
+        )
+        self.request_info: aiohttp.RequestInfo = aiohttp.RequestInfo(
             url=URL(url),
             method=method.upper(),
             headers=self.headers,
             real_url=URL(url),
         )
-        self.history = ()
+        self.history: tuple[aiohttp.ClientResponse, ...] = ()
+        self._body_bytes: bytes
         if isinstance(body, bytes):
             self._body_bytes = body
         elif isinstance(body, str):
@@ -74,33 +86,41 @@ class MockClientResponse:
         else:
             self._body_bytes = b""
 
-    async def text(self, encoding="utf-8", errors="strict"):
+    async def text(self, encoding: str = "utf-8", errors: str = "strict") -> str:
         """Return body as text."""
         return self._body_bytes.decode(encoding=encoding, errors=errors)
 
-    async def read(self):
+    async def read(self) -> bytes:
         """Return body as bytes."""
         return self._body_bytes
 
     async def json(
-        self, encoding="utf-8", loads=json.loads, content_type="application/json"
-    ):
+        self,
+        encoding: str = "utf-8",
+        loads: Callable[[str], Any] = json.loads,
+        content_type: str = "application/json",
+    ) -> Any:
         """Return body parsed as JSON."""
-        return json.loads(self._body_bytes.decode(encoding))
+        return loads(self._body_bytes.decode(encoding))
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "MockClientResponse":
         """Enter response context manager."""
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any | None,
+    ) -> None:
         """Exit response context manager."""
         pass
 
-    def release(self):
+    def release(self) -> None:
         """Release response resource."""
         pass
 
-    def close(self):
+    def close(self) -> None:
         """Close response."""
         pass
 
@@ -108,14 +128,22 @@ class MockClientResponse:
 class AiohttpClientMock:
     """Mock aiohttp ClientSession calls."""
 
-    def __init__(self):
-        self.requests = defaultdict(list)
-        self.mocked_responses = []
-        self._patchers = []
+    def __init__(self) -> None:
+        self.requests: defaultdict[tuple[str, URL], list[MockRequestCall]] = (
+            defaultdict(list)
+        )
+        self.mocked_responses: list[MockResponse] = []
+        self._patchers: list[Any] = []
 
     def get(
-        self, url, status=200, body=None, exception=None, repeat=False, headers=None
-    ):
+        self,
+        url: str | URL,
+        status: int = 200,
+        body: str | bytes | dict[str, Any] | None = None,
+        exception: type[BaseException] | BaseException | None = None,
+        repeat: bool = False,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         """Queue a mocked GET response."""
         self.mocked_responses.append(
             MockResponse(
@@ -130,8 +158,14 @@ class AiohttpClientMock:
         )
 
     def post(
-        self, url, status=200, body=None, exception=None, repeat=False, headers=None
-    ):
+        self,
+        url: str | URL,
+        status: int = 200,
+        body: str | bytes | dict[str, Any] | None = None,
+        exception: type[BaseException] | BaseException | None = None,
+        repeat: bool = False,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         """Queue a mocked POST response."""
         self.mocked_responses.append(
             MockResponse(
@@ -145,20 +179,31 @@ class AiohttpClientMock:
             )
         )
 
-    def __enter__(self):
+    def __enter__(self) -> "AiohttpClientMock":
         """Enter client mock context manager patching ClientSession._request."""
         patcher = patch.object(aiohttp.ClientSession, "_request", new=self._request)
         patcher.start()
         self._patchers.append(patcher)
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any | None,
+    ) -> None:
         """Exit client mock context manager restoring original ClientSession._request."""
         for patcher in reversed(self._patchers):
             patcher.stop()
         self._patchers.clear()
 
-    async def _request(self, method, url, *args, **kwargs):
+    async def _request(
+        self,
+        method: str,
+        url: str | URL,
+        *args: Any,
+        **kwargs: Any,
+    ) -> MockClientResponse:
         method = method.upper()
         url_obj = URL(url)
 
@@ -185,7 +230,12 @@ class AiohttpClientMock:
             ):
                 if matched.exception is aiohttp.ClientResponseError:
                     raise aiohttp.ClientResponseError(
-                        request_info=aiohttp.RequestInfo(url_obj, method, {}, url_obj),
+                        request_info=aiohttp.RequestInfo(
+                            url_obj,
+                            method,
+                            CIMultiDictProxy(CIMultiDict()),
+                            url_obj,
+                        ),
                         history=(),
                         status=matched.status or 500,
                     )
@@ -204,7 +254,7 @@ class AiohttpClientMock:
 
 
 @pytest.fixture(autouse=True)
-def clear_default_cache():
+def clear_default_cache() -> Generator[None]:
     """Move real cache aside before each test and restore it afterwards."""
     had_cache = _DEFAULT_CACHE.exists()
     backup: str | None = None
@@ -222,7 +272,7 @@ def clear_default_cache():
 
 
 @pytest.fixture
-def mock_aioclient():
+def mock_aioclient() -> Generator[AiohttpClientMock]:
     """Fixture to mock aioclient calls."""
     with AiohttpClientMock() as m:
         yield m

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,206 @@
 """Provide common pytest fixtures."""
 
+import json
 import os
 import shutil
 import tempfile
+from collections import defaultdict
 from pathlib import Path
+from unittest.mock import patch
 
+import aiohttp
 import pytest
-from aioresponses import aioresponses
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 TEST_URL = "https://www.gasbuddy.com/graphql"
 
 _DEFAULT_CACHE = Path.home() / ".cache" / "py_gasbuddy" / "token"
+
+
+class MockRequestCall:
+    """Represent a recorded mock request call."""
+
+    def __init__(self, args, kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class MockResponse:
+    """Represent a queued mocked response."""
+
+    def __init__(
+        self,
+        method,
+        url,
+        status=200,
+        body=None,
+        exception=None,
+        repeat=False,
+        headers=None,
+    ):
+        self.method = method.upper()
+        self.url = URL(url)
+        self.status = status
+        self.body = body
+        self.exception = exception
+        self.repeat = repeat
+        self.headers = headers or {}
+
+    def matches(self, method, url):
+        """Check if request method and url match the mocked response."""
+        return self.method == method.upper() and self.url == URL(url)
+
+
+class MockClientResponse:
+    """Mock aiohttp.ClientResponse."""
+
+    def __init__(self, method, url, status, body, headers=None):
+        self.status = status
+        self.headers = CIMultiDictProxy(CIMultiDict(headers or {}))
+        self.request_info = aiohttp.RequestInfo(
+            url=URL(url),
+            method=method.upper(),
+            headers=self.headers,
+            real_url=URL(url),
+        )
+        self.history = ()
+        if isinstance(body, bytes):
+            self._body_bytes = body
+        elif isinstance(body, str):
+            self._body_bytes = body.encode("utf-8")
+        elif body is not None:
+            self._body_bytes = json.dumps(body).encode("utf-8")
+        else:
+            self._body_bytes = b""
+
+    async def text(self, encoding="utf-8", errors="strict"):
+        """Return body as text."""
+        return self._body_bytes.decode(encoding=encoding, errors=errors)
+
+    async def read(self):
+        """Return body as bytes."""
+        return self._body_bytes
+
+    async def json(
+        self, encoding="utf-8", loads=json.loads, content_type="application/json"
+    ):
+        """Return body parsed as JSON."""
+        return json.loads(self._body_bytes.decode(encoding))
+
+    async def __aenter__(self):
+        """Enter response context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit response context manager."""
+        pass
+
+    def release(self):
+        """Release response resource."""
+        pass
+
+    def close(self):
+        """Close response."""
+        pass
+
+
+class AiohttpClientMock:
+    """Mock aiohttp ClientSession calls."""
+
+    def __init__(self):
+        self.requests = defaultdict(list)
+        self.mocked_responses = []
+        self._patchers = []
+
+    def get(
+        self, url, status=200, body=None, exception=None, repeat=False, headers=None
+    ):
+        """Queue a mocked GET response."""
+        self.mocked_responses.append(
+            MockResponse(
+                "GET",
+                url,
+                status=status,
+                body=body,
+                exception=exception,
+                repeat=repeat,
+                headers=headers,
+            )
+        )
+
+    def post(
+        self, url, status=200, body=None, exception=None, repeat=False, headers=None
+    ):
+        """Queue a mocked POST response."""
+        self.mocked_responses.append(
+            MockResponse(
+                "POST",
+                url,
+                status=status,
+                body=body,
+                exception=exception,
+                repeat=repeat,
+                headers=headers,
+            )
+        )
+
+    def __enter__(self):
+        """Enter client mock context manager patching ClientSession._request."""
+        patcher = patch.object(aiohttp.ClientSession, "_request", new=self._request)
+        patcher.start()
+        self._patchers.append(patcher)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit client mock context manager restoring original ClientSession._request."""
+        for patcher in reversed(self._patchers):
+            patcher.stop()
+        self._patchers.clear()
+
+    async def _request(self, method, url, *args, **kwargs):
+        method = method.upper()
+        url_obj = URL(url)
+
+        # Record the request
+        req_call = MockRequestCall(args, kwargs)
+        self.requests[(method, url_obj)].append(req_call)
+
+        # Find matching mocked response
+        matched = None
+        for r in self.mocked_responses:
+            if r.matches(method, url_obj):
+                matched = r
+                break
+
+        if matched is None:
+            raise AssertionError(f"No mocked response found for {method} {url_obj}")
+
+        if not matched.repeat:
+            self.mocked_responses.remove(matched)
+
+        if matched.exception:
+            if isinstance(matched.exception, type) and issubclass(
+                matched.exception, BaseException
+            ):
+                if matched.exception is aiohttp.ClientResponseError:
+                    raise aiohttp.ClientResponseError(
+                        request_info=aiohttp.RequestInfo(url_obj, method, {}, url_obj),
+                        history=(),
+                        status=matched.status or 500,
+                    )
+                else:
+                    raise matched.exception()
+            else:
+                raise matched.exception
+
+        return MockClientResponse(
+            method=method,
+            url=url_obj,
+            status=matched.status,
+            body=matched.body,
+            headers=matched.headers,
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -34,5 +224,5 @@ def clear_default_cache():
 @pytest.fixture
 def mock_aioclient():
     """Fixture to mock aioclient calls."""
-    with aioresponses() as m:
+    with AiohttpClientMock() as m:
         yield m

--- a/uv.lock
+++ b/uv.lock
@@ -89,19 +89,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aioresponses"
-version = "0.7.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
-]
-
-[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -558,7 +545,6 @@ dependencies = [
 
 [package.optional-dependencies]
 test = [
-    { name = "aioresponses" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -571,7 +557,6 @@ test = [
 requires-dist = [
     { name = "aiofiles" },
     { name = "aiohttp" },
-    { name = "aioresponses", marker = "extra == 'test'" },
     { name = "backoff" },
     { name = "pre-commit", marker = "extra == 'test'" },
     { name = "pytest", marker = "extra == 'test'" },


### PR DESCRIPTION
This PR removes `aioresponses` as a test dependency and replaces it with a custom class-based mock `AiohttpClientMock` in `tests/conftest.py`. This ensures we don't depend on external third-party mocking libraries for HTTP requests and gives us precise control over simulating standard and failure-related HTTP responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines, testing documentation, and development guides to reflect the new test mocking approach for developers writing tests.
* **Chores**
  * Improved test infrastructure with custom HTTP request mocking implementation for enhanced control and maintainability.
  * Removed `aioresponses` from test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->