### PR TITLE
fix(logging): introduce redact_data function to mask sensitive tokens in log output

### DIFF
--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -54,6 +54,7 @@ from .parsers import (
     parse_location_results,
     parse_results,
     parse_trends,
+    redact_data,
 )
 
 __all__ = [
@@ -179,7 +180,9 @@ class GasBuddy:
 
         async with self._get_session() as session:
             json_query: str = json.dumps(query)
-            _LOGGER.debug("URL: %s\nQuery: %s", self._url, json_query)
+            _LOGGER.debug(
+                "URL: %s\nQuery: %s", self._url, json.dumps(redact_data(query))
+            )
             request_timeout = aiohttp.ClientTimeout(total=self._timeout / 1000)
             try:
                 async with session.post(
@@ -728,7 +731,7 @@ class GasBuddy:
         csrf_timeout = aiohttp.ClientTimeout(total=self._timeout / 1000)
         async with self._get_session() as session:
             http_method = getattr(session, method)
-            _LOGGER.debug("Calling %s with data: %s", url, json_data)
+            _LOGGER.debug("Calling %s with data: %s", url, redact_data(json_data))
             try:
                 async with http_method(
                     url,
@@ -758,7 +761,7 @@ class GasBuddy:
                         self._tag = found.group(2)
                         data[TOKEN] = self._tag
                         encoded = json.dumps(data).encode("utf-8")
-                        _LOGGER.debug("CSRF token found: %s", self._tag)
+                        _LOGGER.debug("CSRF token found: %s", redact_data(self._tag))
                         if self._cache_manager is not None:
                             await self._cache_manager.write_cache(encoded)
                         # Mark this instance as having a fresh token so

--- a/py_gasbuddy/__init__.py
+++ b/py_gasbuddy/__init__.py
@@ -180,9 +180,8 @@ class GasBuddy:
 
         async with self._get_session() as session:
             json_query: str = json.dumps(query)
-            _LOGGER.debug(
-                "URL: %s\nQuery: %s", self._url, json.dumps(redact_data(query))
-            )
+            operation = query.get("operationName") if isinstance(query, dict) else None
+            _LOGGER.debug("URL: %s (operation: %s)", self._url, operation)
             request_timeout = aiohttp.ClientTimeout(total=self._timeout / 1000)
             try:
                 async with session.post(

--- a/py_gasbuddy/parsers.py
+++ b/py_gasbuddy/parsers.py
@@ -260,3 +260,38 @@ def parse_trends(response: dict[str, Any]) -> list[TrendData]:
         and "todayLow" in trend
         and "areaName" in trend
     ]
+
+
+def redact_data(data: Any) -> Any:
+    """Redact sensitive data (such as tokens or credentials) for logging.
+
+    Args:
+        data: A string, dict, or object that may contain sensitive token data.
+
+    Returns:
+        Data with sensitive values redacted.
+    """
+    if data is None:
+        return None
+    if isinstance(data, str):
+        if not data:
+            return ""
+        if len(data) <= 8:
+            return "***REDACTED***"
+        return f"{data[:2]}***{data[-2:]}"
+    if isinstance(data, dict):
+        redacted: dict[str, Any] = {}
+        for key, value in data.items():
+            if any(
+                s in key.lower()
+                for s in ("token", "secret", "password", "gbcsrf", "authorization")
+            ):
+                redacted[key] = redact_data(value)
+            elif isinstance(value, dict | list):
+                redacted[key] = redact_data(value)
+            else:
+                redacted[key] = value
+        return redacted
+    if isinstance(data, list):
+        return [redact_data(item) for item in data]
+    return data

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -400,7 +400,7 @@ async def test_solver(mock_aioclient, caplog):
         data = await manager.location_search(zipcode=12345)
 
     assert data["results"][0]["station_id"] == "187725"
-    assert "CSRF token found: 1.RiXH1tCtoqNhvBuo" in caplog.text
+    assert "CSRF token found: 1.***uo" in caplog.text
     await manager.clear_cache()
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -251,3 +251,26 @@ def test_parse_ev_stations_non_list_coverage() -> None:
 
     assert parse_ev_stations("not-a-list") == []
     assert parse_ev_stations(None) == []
+
+
+def test_redact_data() -> None:
+    """redact_data redacts sensitive strings, dicts, and lists."""
+    from py_gasbuddy.parsers import redact_data
+
+    assert redact_data(None) is None
+    assert redact_data("") == ""
+    assert redact_data("short") == "***REDACTED***"
+    assert redact_data("very_long_secret_token_value") == "ve***ue"
+    assert redact_data(12345) == 12345
+
+    payload = {
+        "gbcsrf": "my_secret_token_12345",
+        "nested": {"token": "another_token_abc"},
+        "token_list": ["secret_token_123", "public_val"],
+        "normal": "public_data",
+    }
+    redacted = redact_data(payload)
+    assert redacted["gbcsrf"] == "my***45"
+    assert redacted["nested"]["token"] == "an***bc"  # noqa: S105
+    assert redacted["token_list"] == ["se***23", "pu***al"]
+    assert redacted["normal"] == "public_data"


### PR DESCRIPTION
## Summary
Introduces a `redact_data` helper function in `py_gasbuddy.parsers` to mask sensitive data (CSRF tokens, auth tokens, secrets, passwords) prior to logging.

## Details
- Implements `redact_data(data: Any) -> Any` to mask sensitive strings (`"my_secret_token"` -> `"my***en"`, short tokens -> `"***REDACTED***"`), nested dictionaries with sensitive key patterns, and lists.
- Updates debug log calls in `py_gasbuddy/__init__.py` (such as `_LOGGER.debug("CSRF token found: %s", ...)` and GraphQL query logging) to filter through `redact_data`.
- Adds unit tests in `tests/test_parsers.py` covering string, dict, list, `None`, and non-sensitive data redaction.