### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/examples/price-lookup.py
+++ b/examples/price-lookup.py
@@ -56,7 +56,7 @@ async def main() -> None:
     if data.get("phone"):
         print(f"Phone      : {data['phone']}")
     print(f"Address    : {line1}, {city}, {region}")
-    print(f"GPS        : {data['latitude']}, {data['longitude']}")
+    print("GPS        : [REDACTED]")
     print(f"Currency   : {data['currency']}  |  Unit: {data['unit_of_measure']}")
 
     # Hours / status


### PR DESCRIPTION
Potential fix for [https://github.com/firstof9/py-gasbuddy/security/code-scanning/10](https://github.com/firstof9/py-gasbuddy/security/code-scanning/10)

General fix: avoid outputting exact sensitive location data in clear text; either remove it, redact it, or present reduced-precision/coarse information.

Best single fix here (minimal behavior change): keep the “GPS” line but mask coordinates so exact values are not exposed. Update `examples/price-lookup.py` at the print statement on line 59 to emit a redacted placeholder instead of `data['latitude']`/`data['longitude']`. This addresses both alert variants at the same sink and requires no new imports or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
